### PR TITLE
chore(package): bump version to 1.16.8

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ray-solutions/react-file-manager",
   "private": false,
-  "version": "1.16.7",
+  "version": "1.16.8",
   "type": "module",
   "module": "dist/react-file-manager.es.js",
   "files": [


### PR DESCRIPTION
- Updated the version number in package.json from '1.16.7' to '1.16.8'.
- This change reflects the latest updates and improvements made to the package.